### PR TITLE
修复几个BUG

### DIFF
--- a/UiLib/Control/UIList.cpp
+++ b/UiLib/Control/UIList.cpp
@@ -1261,7 +1261,7 @@ namespace UiLib {
 				cxNeeded = MAX(0, pHeader->EstimateSize(CSize(rc.right - rc.left, rc.bottom - rc.top)).cx);
 				if ( m_pVerticalScrollBar && m_pVerticalScrollBar->IsVisible())
 				{
-					int nOffset = m_pHorizontalScrollBar->GetScrollPos();
+					int nOffset = (NULL!=m_pHorizontalScrollBar)?m_pHorizontalScrollBar->GetScrollPos():0; // modify by watertoeast, 2015-11-2
 					RECT rcHeader = pHeader->GetPos();
 					rcHeader.left = rc.left - nOffset;
 					pHeader->SetPos(rcHeader);

--- a/UiLib/Control/UIMenu.cpp
+++ b/UiLib/Control/UIMenu.cpp
@@ -771,6 +771,12 @@ void CMenuElementUI::DoEvent(TEventUI& event)
 			}
 			else
 			{
+				// Moved from bellow by watertoeast, 2015-11-2
+				ContextMenuParam param;
+				param.hWnd = m_pManager->GetPaintWindow();
+				param.wParam = 1;
+				CMenuWnd::GetGlobalContextMenuObserver().RBroadcast(param);
+				// 
 				SetChecked(!GetChecked());
 				if (CMenuWnd::GetGlobalContextMenuObserver().GetManager() != NULL)
 				{
@@ -778,10 +784,6 @@ void CMenuElementUI::DoEvent(TEventUI& event)
 					if (!PostMessage(CMenuWnd::GetGlobalContextMenuObserver().GetManager()->GetPaintWindow(), WM_MENUCLICK, (WPARAM)(strPost), (LPARAM)(GetChecked() == TRUE)))
 						delete strPost;
 				}
-				ContextMenuParam param;
-				param.hWnd = m_pManager->GetPaintWindow();
-				param.wParam = 1;
-				CMenuWnd::GetGlobalContextMenuObserver().RBroadcast(param);
 			}
         }
 

--- a/UiLib/Control/UITreeView.cpp
+++ b/UiLib/Control/UITreeView.cpp
@@ -668,7 +668,7 @@ namespace UiLib
 					Add(pNode);
 			}
 		}
-		else
+		// else // commented by watertoeast, 2015-11-2
 
 		pControl->SetTreeView(this);
 		return true;

--- a/UiLib/Control/UIWebBrowser.cpp
+++ b/UiLib/Control/UIWebBrowser.cpp
@@ -66,6 +66,13 @@ STDMETHODIMP UiLib::CWebBrowserUI::Invoke( DISPID dispIdMember, REFIID riid, LCI
 
 	switch(dispIdMember)
 	{
+		// add by watertoeast, 2015-11-2
+	case DISPID_DOCUMENTCOMPLETE:
+		DocumentComplete(
+			pDispParams->rgvarg[1].pdispVal,
+			pDispParams->rgvarg[0].pvarVal);
+		break;
+		// 
 	case DISPID_BEFORENAVIGATE2:
 		BeforeNavigate2(
 			pDispParams->rgvarg[6].pdispVal,
@@ -216,6 +223,16 @@ void UiLib::CWebBrowserUI::NavigateComplete2( IDispatch *pDisp,VARIANT *&url )
 		m_pWebBrowserEventHandler->NavigateComplete2(pDisp,url);
 	}
 }
+
+// add by watertoeast, 2015-11-2 
+void UiLib::CWebBrowserUI::DocumentComplete( IDispatch *pDisp,VARIANT *&url )
+{
+	if (m_pWebBrowserEventHandler)
+	{
+		m_pWebBrowserEventHandler->DocumentComplete(pDisp,url);
+	}
+}
+// 
 
 void UiLib::CWebBrowserUI::ProgressChange( LONG nProgress, LONG nProgressMax )
 {

--- a/UiLib/Control/UIWebBrowser.h
+++ b/UiLib/Control/UIWebBrowser.h
@@ -60,6 +60,7 @@ namespace UiLib
 		void BeforeNavigate2( IDispatch *pDisp,VARIANT *&url,VARIANT *&Flags,VARIANT *&TargetFrameName,VARIANT *&PostData,VARIANT *&Headers,VARIANT_BOOL *&Cancel );
 		void NavigateError(IDispatch *pDisp,VARIANT * &url,VARIANT *&TargetFrameName,VARIANT *&StatusCode,VARIANT_BOOL *&Cancel);
 		void NavigateComplete2(IDispatch *pDisp,VARIANT *&url);
+		void DocumentComplete(IDispatch *pDisp, VARIANT *&url); // add by watertoeast, 2015-11-2
 		void ProgressChange(LONG nProgress, LONG nProgressMax);
 		void NewWindow3(IDispatch **pDisp, VARIANT_BOOL *&Cancel, DWORD dwFlags, BSTR bstrUrlContext, BSTR bstrUrl);
 		void CommandStateChange(long Command,VARIANT_BOOL Enable);

--- a/UiLib/Core/UIManager.cpp
+++ b/UiLib/Core/UIManager.cpp
@@ -7,6 +7,7 @@ typedef DWORD ZRESULT;
 #define CloseZip(hz) CloseZipU(hz)
 extern HZIP OpenZipU(void *z,unsigned int len,DWORD flags);
 extern ZRESULT CloseZipU(HZIP hz);
+#pragma init_seg(lib) // add by watertoeast, 2015-11-2
 
 namespace UiLib {
 

--- a/UiLib/Utils/WebBrowserEventHandler.h
+++ b/UiLib/Utils/WebBrowserEventHandler.h
@@ -15,6 +15,7 @@ namespace UiLib
 		virtual void BeforeNavigate2( IDispatch *pDisp,VARIANT *&url,VARIANT *&Flags,VARIANT *&TargetFrameName,VARIANT *&PostData,VARIANT *&Headers,VARIANT_BOOL *&Cancel ) {}
 		virtual void NavigateError(IDispatch *pDisp,VARIANT * &url,VARIANT *&TargetFrameName,VARIANT *&StatusCode,VARIANT_BOOL *&Cancel) {}
 		virtual void NavigateComplete2(IDispatch *pDisp,VARIANT *&url){}
+		virtual void DocumentComplete(IDispatch *pDisp,VARIANT *&url){} // add by watertoeast, 2015-11-2
 		virtual void ProgressChange(LONG nProgress, LONG nProgressMax){}
 		virtual void NewWindow3(IDispatch **pDisp, VARIANT_BOOL *&Cancel, DWORD dwFlags, BSTR bstrUrlContext, BSTR bstrUrl){}
 		virtual void CommandStateChange(long Command,VARIANT_BOOL Enable){};


### PR DESCRIPTION
1、lib版本全局变量初始化问题
如果工程中的主窗口类的对象是一个全局变量，编译得到的程序运行会崩溃。原因是不能确保lib中全局变量在窗口对象初始化之前初始化完毕。应该再lib中添加#pragma
init_seg(lib)。
2、Webbrowser没有支持DISPID_DOCUMENTCOMPLETE事件
在多框架的页面中，判断页面加载完毕需要结合DISPID_DOCUMENTCOMPLETE和DISPID_BEFORENAVIGATE2两个事件，作为一个常用功能，应该添加对DISPID_DOCUMENTCOMPLETE的支持。
3、树形控件的根节点无法获取树形控件
bool CTreeViewUI::Add( CTreeNodeUI\* pControl )倒数第三条语句，即else，是否为笔误，因为有这个else后，树形控件的根节点调用GetTreeView得到的是NULL。
4、响应菜单消息时，调用mfc对话框崩溃
CMenuElementUI::DoEvent(TEventUI&
event)函数中，先发送菜单消息，然后销毁菜单窗口，这种情况下，在响应菜单消息时调用mfc对话框出现ASSERT断言错误。是否可以把送菜单消息，销毁菜单窗口顺序对调下（对调后测试时正常了，尚不确定是否会有其他问题）。
5、解决List控件崩溃问题
如果list设置hscrollbar="false"，UIList.cpp line 1264 int nOffset =
m_pHorizontalScrollBar->GetScrollPos();的m_pHorizontalScrollBar是NULL。
