### PR TITLE
2处小bug

### DIFF
--- a/DuiLib/Utils/UIShadow.cpp
+++ b/DuiLib/Utils/UIShadow.cpp
@@ -103,6 +103,17 @@ void CShadowUI::Create(CPaintManagerUI* pPaintManager)
 
 }
 
+bool CShadowUI::UpdateNow()
+{
+	bool bRet = false;
+	if (m_hWnd)
+	{
+		Update(GetParent(m_hWnd));
+		bRet = true;
+	}
+	return bRet;
+}
+
 std::map<HWND, CShadowUI *>& CShadowUI::GetShadowMap()
 {
 	static std::map<HWND, CShadowUI *> s_Shadowmap;

--- a/DuiLib/Utils/UIShadow.h
+++ b/DuiLib/Utils/UIShadow.h
@@ -72,6 +72,9 @@ public:
 
 	//	创建阴影窗体，由CPaintManagerUI自动调用,除非自己要单独创建阴影
 	void Create(CPaintManagerUI* pPaintManager);
+	
+	// 手动调用刷新，重新生成阴影
+	bool UpdateNow();
 protected:
 
 	//	初始化并注册阴影类

--- a/DuiLib/Utils/WinImplBase.cpp
+++ b/DuiLib/Utils/WinImplBase.cpp
@@ -240,7 +240,12 @@ LRESULT WindowImplBase::OnSysCommand(UINT uMsg, WPARAM wParam, LPARAM lParam, BO
 			pbtnMax->SetVisible(TRUE == bZoomed);       // 此处用表达式是为了避免编译器BOOL转换的警告
 			pbtnRestore->SetVisible(FALSE == bZoomed);
 		}
-		
+		// Fixed: Bug::20180512 修复从WindowImplBase派生的子类窗体，开启阴影显示。
+    // 最小化 ---》点击任务栏显示--》点击最大化 ----》点击任务栏，最小化---》点击任务栏显示。这个时候就会发现阴影窗体显示异常。
+		if (m_PaintManager.GetShadow())
+		{
+			m_PaintManager.GetShadow()->UpdateNow();
+		}
 	}
 #else
 	LRESULT lRes = CWindowWnd::HandleMessage(uMsg, wParam, lParam);

--- a/DuiLib/Utils/WinImplBase.h
+++ b/DuiLib/Utils/WinImplBase.h
@@ -48,7 +48,6 @@ namespace DuiLib
 #if defined(WIN32) && !defined(UNDER_CE)
 		virtual LRESULT OnNcActivate(UINT /*uMsg*/, WPARAM wParam, LPARAM /*lParam*/, BOOL& bHandled);
 		virtual LRESULT OnNcCalcSize(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
-		virtual LRESULT OnWindowPosChanging(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
 		virtual LRESULT OnNcPaint(UINT /*uMsg*/, WPARAM /*wParam*/, LPARAM /*lParam*/, BOOL& /*bHandled*/);
 		virtual LRESULT OnNcHitTest(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
 		virtual LRESULT OnGetMinMaxInfo(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);


### PR DESCRIPTION
Fixed Bug::20180512 从WindowImplBase派生的子类窗体，双屏下面副屏分辨率大于主屏时，最大化软件，点击任务栏切换最大/最小化, 界面不正确的问题

Fixed: Bug::20180512 从WindowImplBase派生的子类窗体，开启阴影显示。
执行以下操作：
最小化 ---》点击任务栏显示--》点击最大化 ----》点击任务栏，最小化---》点击任务栏显示。
这个时候就会发现阴影窗体显示异常。